### PR TITLE
Fix: Fixing Hardcoded URL

### DIFF
--- a/src/services/deleteUser.js
+++ b/src/services/deleteUser.js
@@ -1,6 +1,6 @@
 const deleteUser = async (id) => {
   try {
-    const url = `http://localhost:4000/users/${id}`;
+    const url = `${process.env.BACKEND_URL}/users/${id}`;
 
     const response = await fetch(url, {
       method: 'DELETE',


### PR DESCRIPTION
Content:
* The URL for the Delete User Service as not using BACKEND_URL from process.env but a hardcoded value from the local instance of the backend. This is being fixed here.